### PR TITLE
Avoid printing message in error level when DEVICE_METADATA|localhost updates

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1369,8 +1369,12 @@ class DeviceMetaCfg(object):
             run_cmd('sudo monit reload')
         else:
             msg = 'Hostname was not updated: '
-            msg += 'Already set up' if new_hostname else 'Empty not allowed'
-            syslog.syslog(syslog.LOG_ERR, msg)
+            if new_hostname:
+                msg += 'Already set up'
+                syslog.syslog(syslog.LOG_INFO, msg)
+            else:
+                msg += 'Empty not allowed'
+                syslog.syslog(syslog.LOG_ERR, msg)
 
 
 class MgmtIfaceCfg(object):

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -420,6 +420,37 @@ class TestHostcfgdDaemon(TestCase):
             mocked_subprocess.check_call.assert_has_calls(expected,
                                                           any_order=True)
 
+        # Mock empty name
+        HOSTCFG_DAEMON_CFG_DB["DEVICE_METADATA"]["localhost"]["hostname"] = ""
+        original_syslog = hostcfgd.syslog
+        MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
+        with mock.patch('hostcfgd.syslog') as mocked_syslog:
+            mocked_syslog.LOG_ERR = original_syslog.LOG_ERR
+            try:
+                daemon.start()
+            except TimeoutError:
+                pass
+
+            expected = [
+                call(original_syslog.LOG_ERR, 'Hostname was not updated: Empty not allowed')
+            ]
+            mocked_syslog.syslog.assert_has_calls(expected)
+
+        daemon.devmetacfg.hostname = "SameHostName"
+        HOSTCFG_DAEMON_CFG_DB["DEVICE_METADATA"]["localhost"]["hostname"] = daemon.devmetacfg.hostname
+        MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
+        with mock.patch('hostcfgd.syslog') as mocked_syslog:
+            mocked_syslog.LOG_INFO = original_syslog.LOG_INFO
+            try:
+                daemon.start()
+            except TimeoutError:
+                pass
+
+            expected = [
+                call(original_syslog.LOG_INFO, 'Hostname was not updated: Already set up')
+            ]
+            mocked_syslog.syslog.assert_has_calls(expected)
+
     def test_mgmtiface_event(self):
         """
         Test handling mgmt events.


### PR DESCRIPTION
There is error message logged on receiving `DEVICE_METADATA|localhost.hostname` update with the same value `DeviceMetaCfg.hostname`.
However, this can happen when other fields in `DEVICE_METADATA|localhost` are updated after `hostname` is recorded by `DeviceMetaCfg`. In this case, `INFO` is preferred.

Signed-off-by: Stephen Sun <stephens@nvidia.com>